### PR TITLE
feat: wrap app with QueryProvider in root layout

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import { Montserrat } from 'next/font/google';
 import './globals.css';
+import QueryProvider from '@/components/layout/QueryProvider/QueryProvider';
 
 const montserrat = Montserrat({
   subsets: ['latin'],
@@ -20,7 +21,9 @@ export default function RootLayout({
 }) {
   return (
     <html lang="uk">
-      <body className={montserrat.className}>{children}</body>
+      <body className={montserrat.className}>
+        <QueryProvider>{children}</QueryProvider>
+      </body>
     </html>
   );
 }

--- a/components/layout/QueryProvider/QueryProvider.tsx
+++ b/components/layout/QueryProvider/QueryProvider.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactNode, useState } from 'react';
 

--- a/components/layout/QueryProvider/QueryProvider.tsx
+++ b/components/layout/QueryProvider/QueryProvider.tsx
@@ -1,0 +1,23 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ReactNode, useState } from 'react';
+
+type Props = {
+  children: ReactNode;
+};
+
+export default function QueryProvider({ children }: Props) {
+  const [queryClient] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            retry: 1,
+            refetchOnWindowFocus: false,
+          },
+        },
+      }),
+  );
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}

--- a/lib/api/api.ts
+++ b/lib/api/api.ts
@@ -1,0 +1,24 @@
+import axios from 'axios';
+import { cookies } from 'next/headers';
+
+const baseURL = process.env.NEXT_PUBLIC_API_URL;
+
+//  Клиентский axios
+export const clientApi = axios.create({
+  baseURL,
+  withCredentials: true,
+});
+
+//  Серверный axios
+export const serverApi = axios.create({
+  baseURL,
+  withCredentials: true,
+});
+
+// Cookie для SSR запросов
+export const getAuthHeaders = async () => {
+  const cookieStore = cookies();
+  const cookieString = cookieStore.toString();
+
+  return cookieString ? { Cookie: cookieString } : {};
+};

--- a/lib/api/api.ts
+++ b/lib/api/api.ts
@@ -1,24 +1,10 @@
 import axios from 'axios';
-import { cookies } from 'next/headers';
 
 const baseURL = process.env.NEXT_PUBLIC_API_URL;
 
-//  Клиентский axios
-export const clientApi = axios.create({
+const instance = axios.create({
   baseURL,
   withCredentials: true,
 });
 
-//  Серверный axios
-export const serverApi = axios.create({
-  baseURL,
-  withCredentials: true,
-});
-
-// Cookie для SSR запросов
-export const getAuthHeaders = async () => {
-  const cookieStore = cookies();
-  const cookieString = cookieStore.toString();
-
-  return cookieString ? { Cookie: cookieString } : {};
-};
+export default instance;

--- a/lib/api/serverApi.ts
+++ b/lib/api/serverApi.ts
@@ -1,0 +1,8 @@
+import { cookies } from 'next/headers';
+
+export const getAuthHeaders = async () => {
+  const cookieStore = cookies();
+  const cookieString = cookieStore.toString();
+
+  return cookieString ? { Cookie: cookieString } : {};
+};


### PR DESCRIPTION
 Що зроблено

- Налаштовано `QueryProvider` з використанням React Query
- Ініціалізовано `QueryClient` з базовими налаштуваннями (retry, refetchOnWindowFocus)
- Обгорнуто весь додаток у `QueryProvider` в `root layout.tsx`

##  Деталі реалізації

- `QueryProvider` реалізований як клієнтський компонент (`use client`)
- Використано `useState` для створення стабільного екземпляра `QueryClient`
- Провайдер підключений на рівні `app/layout.tsx`, що забезпечує глобальний доступ до React Query у всіх компонентах

##  Результат

- React Query доступний у будь-якому компоненті додатку
- Централізоване управління серверним станом
- Готова база для роботи з API (fetch, caching, mutations)

##  Як перевірити

- Запустити додаток
- Використати `useQuery` або `useMutation` у будь-якому компоненті
- Переконатися, що помилка `No QueryClient set` відсутня

##  Пов'язано

- Підготовка до інтеграції API та роботи з даними через React Query