### PR TITLE
feat: implement Next.js API routes for auth, stories and travellers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,2 @@
 NEXT_PUBLIC_API_URL=http://localhost:3000/api
+

--- a/app/api/api.ts
+++ b/app/api/api.ts
@@ -1,0 +1,8 @@
+import axios from 'axios';
+
+const baseURL = process.env.BACKEND_URL;
+
+export const serverApi = axios.create({
+  baseURL,
+  withCredentials: true,
+});

--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -1,25 +1,21 @@
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
+import { serverApi } from '@/lib/api/serverApi';
+import { AxiosError } from 'axios';
+import { LoginBody } from '@/types/auth';
 
-export async function POST(req: Request) {
+export async function POST(req: NextRequest) {
   try {
-    const body = await req.json();
+    const body: LoginBody = await req.json();
 
-    const res = await fetch(`${process.env.BACKEND_URL}/auth/login`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify(body),
-    });
-
-    const data = await res.json();
-
-    if (!res.ok) {
-      return NextResponse.json(data, { status: res.status });
-    }
+    const { data } = await serverApi.post('/auth/login', body);
 
     return NextResponse.json(data);
-  } catch {
-    return NextResponse.json({ message: 'Server error' }, { status: 500 });
+  } catch (error) {
+    const err = error as AxiosError<{ message: string }>;
+
+    return NextResponse.json(
+      { message: err.response?.data?.message || 'Login error' },
+      { status: err.response?.status || 500 },
+    );
   }
 }

--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from 'next/server';
+
+export async function POST(req: Request) {
+  try {
+    const body = await req.json();
+
+    const res = await fetch(`${process.env.BACKEND_URL}/auth/login`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(body),
+    });
+
+    const data = await res.json();
+
+    if (!res.ok) {
+      return NextResponse.json(data, { status: res.status });
+    }
+
+    return NextResponse.json(data);
+  } catch {
+    return NextResponse.json({ message: 'Server error' }, { status: 500 });
+  }
+}

--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { serverApi } from '@/lib/api/serverApi';
+import { serverApi } from '@/app/api/api';
 import { AxiosError } from 'axios';
 import { LoginBody } from '@/types/auth';
 

--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -1,21 +1,35 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { serverApi } from '@/app/api/api';
-import { AxiosError } from 'axios';
-import { LoginBody } from '@/types/auth';
+import { cookies } from 'next/headers';
+import { parse } from 'cookie';
 
 export async function POST(req: NextRequest) {
   try {
-    const body: LoginBody = await req.json();
+    const body = await req.json();
 
-    const { data } = await serverApi.post('/auth/login', body);
+    const res = await serverApi.post('/auth/login', body);
 
-    return NextResponse.json(data);
-  } catch (error) {
-    const err = error as AxiosError<{ message: string }>;
+    const cookieStore = await cookies();
+    const setCookie = res.headers['set-cookie'];
 
-    return NextResponse.json(
-      { message: err.response?.data?.message || 'Login error' },
-      { status: err.response?.status || 500 },
-    );
+    if (setCookie) {
+      const cookieArray = Array.isArray(setCookie) ? setCookie : [setCookie];
+
+      for (const cookieStr of cookieArray) {
+        const parsed = parse(cookieStr);
+
+        if (parsed.accessToken) {
+          cookieStore.set('accessToken', parsed.accessToken);
+        }
+
+        if (parsed.refreshToken) {
+          cookieStore.set('refreshToken', parsed.refreshToken);
+        }
+      }
+    }
+
+    return NextResponse.json(res.data);
+  } catch {
+    return NextResponse.json({ message: 'Login error' }, { status: 500 });
   }
 }

--- a/app/api/auth/logout/route.ts
+++ b/app/api/auth/logout/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
+
+export async function POST() {
+  try {
+    const cookieStore = await cookies();
+
+    cookieStore.delete('token');
+
+    return new NextResponse(null, { status: 204 });
+  } catch {
+    return NextResponse.json({ message: 'Logout error' }, { status: 500 });
+  }
+}

--- a/app/api/auth/logout/route.ts
+++ b/app/api/auth/logout/route.ts
@@ -11,7 +11,8 @@ export async function POST() {
     await serverApi.post('/auth/logout', {}, { headers });
 
     const cookieStore = await cookies();
-    cookieStore.delete('token');
+    cookieStore.delete('accessToken');
+    cookieStore.delete('refreshToken');
 
     return new NextResponse(null, { status: 204 });
   } catch (error) {

--- a/app/api/auth/logout/route.ts
+++ b/app/api/auth/logout/route.ts
@@ -1,14 +1,25 @@
 import { NextResponse } from 'next/server';
+import { serverApi } from '@/app/api/api';
+import { getAuthHeaders } from '@/lib/api/serverApi';
 import { cookies } from 'next/headers';
+import { AxiosError } from 'axios';
 
 export async function POST() {
   try {
-    const cookieStore = await cookies();
+    const headers = await getAuthHeaders();
 
+    await serverApi.post('/auth/logout', {}, { headers });
+
+    const cookieStore = await cookies();
     cookieStore.delete('token');
 
     return new NextResponse(null, { status: 204 });
-  } catch {
-    return NextResponse.json({ message: 'Logout error' }, { status: 500 });
+  } catch (error) {
+    const err = error as AxiosError<{ message: string }>;
+
+    return NextResponse.json(
+      { message: err.response?.data?.message || 'Logout error' },
+      { status: err.response?.status || 500 },
+    );
   }
 }

--- a/app/api/auth/register/route.ts
+++ b/app/api/auth/register/route.ts
@@ -1,21 +1,44 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { serverApi } from '@/app/api/api';
-import { AxiosError } from 'axios';
-import { RegisterBody } from '@/types/auth';
+import { cookies } from 'next/headers';
+import { parse } from 'cookie';
 
 export async function POST(req: NextRequest) {
   try {
-    const body: RegisterBody = await req.json();
+    const body = await req.json();
 
-    const { data } = await serverApi.post('/auth/register', body);
+    await serverApi.post('/auth/register', body);
 
-    return NextResponse.json(data);
+    const loginRes = await serverApi.post('/auth/login', {
+      email: body.email,
+      password: body.password,
+    });
+
+    const cookieStore = await cookies();
+    const setCookie = loginRes.headers['set-cookie'];
+
+    if (setCookie) {
+      const cookieArray = Array.isArray(setCookie) ? setCookie : [setCookie];
+
+      for (const cookieStr of cookieArray) {
+        const parsed = parse(cookieStr);
+
+        if (parsed.refreshToken) {
+          cookieStore.set('refreshToken', parsed.refreshToken);
+        }
+
+        if (parsed.accessToken) {
+          cookieStore.set('accessToken', parsed.accessToken);
+        }
+      }
+    } else {
+      console.log('set-cookie не пришёл');
+    }
+
+    return NextResponse.json(loginRes.data);
   } catch (error) {
-    const err = error as AxiosError<{ message: string }>;
+    console.log('REGISTER ERROR:', error);
 
-    return NextResponse.json(
-      { message: err.response?.data?.message || 'Register error' },
-      { status: err.response?.status || 500 },
-    );
+    return NextResponse.json({ message: 'Register error' }, { status: 500 });
   }
 }

--- a/app/api/auth/register/route.ts
+++ b/app/api/auth/register/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from 'next/server';
+
+export async function POST(req: Request) {
+  try {
+    const body = await req.json();
+
+    const res = await fetch(`${process.env.BACKEND_URL}/auth/register`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(body),
+    });
+
+    const data = await res.json();
+
+    if (!res.ok) {
+      return NextResponse.json(data, { status: res.status });
+    }
+
+    return NextResponse.json(data);
+  } catch {
+    return NextResponse.json({ message: 'Server error' }, { status: 500 });
+  }
+}

--- a/app/api/auth/register/route.ts
+++ b/app/api/auth/register/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { serverApi } from '@/lib/api/serverApi';
+import { serverApi } from '@/app/api/api';
 import { AxiosError } from 'axios';
 import { RegisterBody } from '@/types/auth';
 

--- a/app/api/auth/register/route.ts
+++ b/app/api/auth/register/route.ts
@@ -1,25 +1,21 @@
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
+import { serverApi } from '@/lib/api/serverApi';
+import { AxiosError } from 'axios';
+import { RegisterBody } from '@/types/auth';
 
-export async function POST(req: Request) {
+export async function POST(req: NextRequest) {
   try {
-    const body = await req.json();
+    const body: RegisterBody = await req.json();
 
-    const res = await fetch(`${process.env.BACKEND_URL}/auth/register`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify(body),
-    });
-
-    const data = await res.json();
-
-    if (!res.ok) {
-      return NextResponse.json(data, { status: res.status });
-    }
+    const { data } = await serverApi.post('/auth/register', body);
 
     return NextResponse.json(data);
-  } catch {
-    return NextResponse.json({ message: 'Server error' }, { status: 500 });
+  } catch (error) {
+    const err = error as AxiosError<{ message: string }>;
+
+    return NextResponse.json(
+      { message: err.response?.data?.message || 'Register error' },
+      { status: err.response?.status || 500 },
+    );
   }
 }

--- a/app/api/stories/popular/route.ts
+++ b/app/api/stories/popular/route.ts
@@ -1,17 +1,15 @@
 import { NextResponse } from 'next/server';
+import { serverApi } from '@/lib/api/serverApi';
 
 export async function GET() {
   try {
-    const res = await fetch(`${process.env.BACKEND_URL}/stories/popular`);
-
-    const data = await res.json();
-
-    if (!res.ok) {
-      return NextResponse.json(data, { status: res.status });
-    }
+    const { data } = await serverApi.get('/stories/popular');
 
     return NextResponse.json(data);
   } catch {
-    return NextResponse.json({ message: 'Server error' }, { status: 500 });
+    return NextResponse.json(
+      { message: 'Failed to fetch stories' },
+      { status: 500 },
+    );
   }
 }

--- a/app/api/stories/popular/route.ts
+++ b/app/api/stories/popular/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from 'next/server';
+
+export async function GET() {
+  try {
+    const res = await fetch(`${process.env.BACKEND_URL}/stories/popular`);
+
+    const data = await res.json();
+
+    if (!res.ok) {
+      return NextResponse.json(data, { status: res.status });
+    }
+
+    return NextResponse.json(data);
+  } catch {
+    return NextResponse.json({ message: 'Server error' }, { status: 500 });
+  }
+}

--- a/app/api/stories/popular/route.ts
+++ b/app/api/stories/popular/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { serverApi } from '@/lib/api/serverApi';
+import { serverApi } from '@/app/api/api';
 
 export async function GET() {
   try {

--- a/app/api/travellers/route.ts
+++ b/app/api/travellers/route.ts
@@ -1,12 +1,23 @@
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import { serverApi } from '@/app/api/api';
 import { getAuthHeaders } from '@/lib/api/serverApi';
 
-export async function GET() {
+export async function GET(req: NextRequest) {
   try {
     const headers = await getAuthHeaders();
 
-    const { data } = await serverApi.get('/travellers', { headers });
+    const { searchParams } = new URL(req.url);
+
+    const page = searchParams.get('page');
+    const limit = searchParams.get('limit');
+
+    const { data } = await serverApi.get('/travellers', {
+      headers,
+      params: {
+        page,
+        limit,
+      },
+    });
 
     return NextResponse.json(data);
   } catch {

--- a/app/api/travellers/route.ts
+++ b/app/api/travellers/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { serverApi } from '@/lib/api/serverApi';
+import { serverApi } from '@/app/api/api';
 import { getAuthHeaders } from '@/lib/api/serverApi';
 
 export async function GET() {

--- a/app/api/travellers/route.ts
+++ b/app/api/travellers/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from 'next/server';
+
+export async function GET() {
+  try {
+    const res = await fetch(`${process.env.BACKEND_URL}/travellers`);
+
+    const data = await res.json();
+
+    if (!res.ok) {
+      return NextResponse.json(data, { status: res.status });
+    }
+
+    return NextResponse.json(data);
+  } catch {
+    return NextResponse.json({ message: 'Server error' }, { status: 500 });
+  }
+}

--- a/app/api/travellers/route.ts
+++ b/app/api/travellers/route.ts
@@ -1,17 +1,18 @@
 import { NextResponse } from 'next/server';
+import { serverApi } from '@/lib/api/serverApi';
+import { getAuthHeaders } from '@/lib/api/serverApi';
 
 export async function GET() {
   try {
-    const res = await fetch(`${process.env.BACKEND_URL}/travellers`);
+    const headers = await getAuthHeaders();
 
-    const data = await res.json();
-
-    if (!res.ok) {
-      return NextResponse.json(data, { status: res.status });
-    }
+    const { data } = await serverApi.get('/travellers', { headers });
 
     return NextResponse.json(data);
   } catch {
-    return NextResponse.json({ message: 'Server error' }, { status: 500 });
+    return NextResponse.json(
+      { message: 'Failed to fetch travellers' },
+      { status: 500 },
+    );
   }
 }

--- a/lib/api/serverApi.ts
+++ b/lib/api/serverApi.ts
@@ -1,12 +1,4 @@
-import axios from 'axios';
 import { cookies } from 'next/headers';
-
-const baseURL = process.env.BACKEND_URL;
-
-export const serverApi = axios.create({
-  baseURL,
-  withCredentials: true,
-});
 
 export const getAuthHeaders = async () => {
   const cookieStore = await cookies();

--- a/lib/api/serverApi.ts
+++ b/lib/api/serverApi.ts
@@ -1,7 +1,15 @@
+import axios from 'axios';
 import { cookies } from 'next/headers';
 
+const baseURL = process.env.BACKEND_URL;
+
+export const serverApi = axios.create({
+  baseURL,
+  withCredentials: true,
+});
+
 export const getAuthHeaders = async () => {
-  const cookieStore = cookies();
+  const cookieStore = await cookies();
   const cookieString = cookieStore.toString();
 
   return cookieString ? { Cookie: cookieString } : {};

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@tanstack/react-query": "^5.95.2",
         "axios": "^1.13.6",
         "clsx": "^2.1.1",
+        "cookie": "^1.1.1",
         "formik": "^2.4.9",
         "modern-normalize": "^3.0.1",
         "next": "16.2.1",
@@ -87,6 +88,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1347,6 +1349,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1406,6 +1409,7 @@
       "integrity": "sha512-30ScMRHIAD33JJQkgfGW1t8CURZtjc2JpTrq5n2HFhOefbAhb7ucc7xJwdWcrEtqUIYJ73Nybpsggii6GtAHjA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.2",
         "@typescript-eslint/types": "8.57.2",
@@ -1931,6 +1935,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2243,6 +2248,7 @@
       "integrity": "sha512-Ixm8tFfoKKIPYdCCKYTsqv+Fd4IJ0DQqMyEimo+pxUOMUR9cVPlwTrFt9Avu+3cb6Zp3mAzl+t1MrG2fxxKsxw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/types": "^7.26.0"
       }
@@ -2310,6 +2316,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2481,6 +2488,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -2500,7 +2520,8 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -2896,6 +2917,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3081,6 +3103,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -5113,6 +5136,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5122,6 +5146,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -5859,6 +5884,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6039,6 +6065,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6326,6 +6353,7 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@tanstack/react-query": "^5.95.2",
     "axios": "^1.13.6",
     "clsx": "^2.1.1",
+    "cookie": "^1.1.1",
     "formik": "^2.4.9",
     "modern-normalize": "^3.0.1",
     "next": "16.2.1",

--- a/types/auth.ts
+++ b/types/auth.ts
@@ -1,0 +1,10 @@
+export interface RegisterBody {
+  name: string;
+  email: string;
+  password: string;
+}
+
+export interface LoginBody {
+  email: string;
+  password: string;
+}


### PR DESCRIPTION
Реалізовано API routes в Next.js (BFF шар) для взаємодії з бекендом.

Додано:
- POST /api/auth/register — реєстрація користувача
- POST /api/auth/login — авторизація користувача
- POST /api/auth/logout — вихід з системи (видалення httpOnly cookie)
- GET /api/stories/popular — отримання популярних історій
- GET /api/travellers — отримання списку мандрівників

Реалізовано:
- проксування запитів до бекенду через BACKEND_URL
- обробку помилок (400, 401, 500)
- повернення відповідей у форматі JSON