### PR TITLE
fix(ui): improve CustomLink transitions and PasswordInput layout with…

### DIFF
--- a/components/ui/Link/Link.module.css
+++ b/components/ui/Link/Link.module.css
@@ -65,8 +65,8 @@
   color: var(--color-white);
   line-height: 150%;
   transition:
-    background-color var(--transition-base),
-    transform var(--transition-base);
+    background-color var(--transition-default),
+    transform var(--transition-default);
   border: 1px solid transparent;
 }
 
@@ -82,4 +82,38 @@
   pointer-events: none;
   cursor: not-allowed;
   border: 1px solid var(--color-mantis-dark);
+}
+
+.secondary {
+  background: var(--opacity-neutral-darkest-5);
+  color: var(--color-scheme-2-text);
+  border-color: var(--color-scheme-2-border);
+  padding: 6px 12px;
+  border-radius: 6px;
+  font-family: var(--font-family);
+  font-weight: 500;
+  font-size: 16px;
+  cursor: pointer;
+  gap: 8px;
+  border: 1px solid transparent;
+  transition: all var(--transition-default);
+  width: 100%;
+}
+
+.secondary:hover:not(:disabled) {
+  border-color: var(--opacity-neutral-darkest-5);
+  background: var(--color-mantis-dark);
+  color: var(--color-white);
+}
+.secondary:active:not(:disabled) {
+  background: var(--color-mantis-darker);
+  color: var(--color-white);
+  border-color: var(--opacity-transparent);
+}
+
+.secondary:disabled {
+  background: var(--opacity-neutral-darkest-5);
+  opacity: 0.3;
+  color: var(--color-scheme-2-text);
+  border-color: var(--opacity-transparent);
 }

--- a/components/ui/Pagination/Pagination.module.css
+++ b/components/ui/Pagination/Pagination.module.css
@@ -8,8 +8,8 @@
 
 .loadMoreBtn {
   height: 48px;
-  padding: 6px 12px !important;
-  border-radius: 6px !important;
+  padding: 6px 12px;
+  border-radius: 6px;
   font-size: 16px;
   font-weight: 500;
   color: var(--color-white);
@@ -30,9 +30,9 @@
 }
 
 .loadMoreBtn {
-  background-color: var(--color-mantis-dark) !important;
-  border: 1px solid var(--color-mantis-dark) !important;
-  color: var(--color-white) !important;
+  background-color: var(--color-mantis-dark);
+  border: 1px solid var(--color-mantis-dark);
+  color: var(--color-white);
 }
 
 .loadMoreBtn:hover {

--- a/components/ui/PasswordInput/PasswordInput.module.css
+++ b/components/ui/PasswordInput/PasswordInput.module.css
@@ -1,5 +1,5 @@
 .passwordField input {
-  padding-right: 44px !important;
+  padding-right: 44px;
 }
 
 .wrapper {
@@ -10,7 +10,7 @@
 .eyeButton {
   position: absolute;
   right: 12px;
-  top: 50%;
+  top: 2.75rem;
   transform: translateY(-50%);
   display: flex;
   align-items: center;
@@ -22,24 +22,23 @@
   color: var(--color-neutral-dark);
   transition: var(--transition-default);
   z-index: 2;
+
+  opacity: 0;
+  pointer-events: none;
 }
 
-.eyeIcon {
-  width: 20px;
-  height: 20px;
-  display: block;
+.wrapper:focus-within .eyeButton {
+  opacity: 1;
+  pointer-events: auto;
 }
+
 .eyeButton:hover {
   opacity: 0.7;
 }
 
-.wrapper:hover .eyeButton {
-  opacity: 1;
-}
-
 .eyeIcon {
-  width: 20px;
-  height: 20px;
+  width: 17px;
+  height: 17px;
   fill: var(--color-neutral-dark);
   transition: fill var(--transition-default);
   display: block;
@@ -47,7 +46,4 @@
 
 .eyeButton:hover .eyeIcon {
   fill: var(--color-scheme-1-accent);
-}
-.passwordField {
-  padding-right: 44px;
 }

--- a/components/ui/PasswordInput/PasswordInput.tsx
+++ b/components/ui/PasswordInput/PasswordInput.tsx
@@ -40,8 +40,8 @@ export const PasswordInput = forwardRef<HTMLInputElement, PasswordInputProps>(
           <Icon
             name={iconId}
             className={styles.eyeIcon}
-            width={20}
-            height={20}
+            width={15}
+            height={15}
           />
         </button>
       </div>


### PR DESCRIPTION
Оновлення в межах UI-рефакторингу:

CustomLink:

Додано варіант secondary.

Виправлено «блимання» ховеру: тепер transition плавно змінює background-color та color одночасно.

PasswordInput:

Реалізовано появу кнопки «ока» тільки при фокусі на інпуті (:focus-within).

Позиціювання: Замість відсоткового top використано 2.75rem. Це гарантує стабільне положення іконки по центру інпута, навіть якщо з'являється повідомлення про помилку (яке раніше зміщувало іконку вниз).