### PR TITLE
Feat/setup global notification 63

### DIFF
--- a/app/(public routes)/travellers/page.tsx
+++ b/app/(public routes)/travellers/page.tsx
@@ -3,7 +3,22 @@ import TravellersList from '@/components/TravellersPage/TravellersList/Traveller
 
 export const metadata: Metadata = {
   title: 'Мандрівники',
-  description: 'Список свідомих мандрівників нашої спільноти',
+  description:
+    'Познайомтеся зі спільнотою "Природні Мандри". Відкривайте нові обличчя, читайте історії успіху та надихайтеся досвідом інших дослідників природи.',
+  openGraph: {
+    title: 'Мандрівники спільноти "Природні Мандри"',
+    description:
+      'Знайдіть однодумців для нових подорожей та дізнайтеся більше про активних учасників нашої спільноти.',
+    images: [
+      {
+        url: '/public/Image/Hero.webp',
+        width: 1200,
+        height: 630,
+        alt: 'Спільнота мандрівників',
+      },
+    ],
+    type: 'website',
+  },
 };
 
 const TravellersPage = () => {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,7 @@ import './globals.css';
 import QueryProvider from '@/components/layout/QueryProvider/QueryProvider';
 import AppLayout from '@/components/layout/AppLayout/AppLayout';
 import AuthProvider from '@/components/providers/AuthProvider';
+import ToasterProvider from '@/components/providers/ToasterProvider';
 const montserrat = Montserrat({
   subsets: ['latin'],
   weight: ['400', '500', '600', '700'],
@@ -42,6 +43,7 @@ export default function RootLayout({
     <html lang="uk" suppressHydrationWarning>
       <body className={montserrat.className}>
         <QueryProvider>
+          <ToasterProvider />
           <AppLayout>
             <AuthProvider>{children}</AuthProvider>
           </AppLayout>

--- a/components/providers/ToasterProvider.tsx
+++ b/components/providers/ToasterProvider.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import { Toaster } from 'react-hot-toast';
+
+const ToasterProvider = () => {
+  return (
+    <Toaster
+      position="top-right"
+      reverseOrder={false}
+      gutter={12}
+      toastOptions={{
+        duration: 4000,
+        style: {
+          background: 'var(--color-scheme-2-background)',
+          color: 'var(--color-scheme-2-text);',
+          borderRadius: '12px',
+          fontSize: '18px',
+          fontWeight: 500,
+          padding: '16px 20px',
+          border: '1px solid #1eb441',
+          boxShadow: '0 4px 12px rgba(0, 0, 0, 0.08)',
+          minWidth: '350px',
+        },
+        success: {
+          style: {
+            border: '1px solid #A3D9B1',
+          },
+          iconTheme: {
+            primary: '#2D9CDB',
+            secondary: '#F0F9F4',
+          },
+        },
+        error: {
+          style: {
+            background: '#FFF5F5',
+            border: '1px solid #FFCCCC',
+            color: '#CB2431',
+          },
+          iconTheme: {
+            primary: '#CB2431',
+            secondary: '#FFF5F5',
+          },
+        },
+      }}
+    />
+  );
+};
+export default ToasterProvider;

--- a/lib/api/api.ts
+++ b/lib/api/api.ts
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import toast from 'react-hot-toast';
 
 const baseURL =
   process.env.NEXT_PUBLIC_API_URL ||
@@ -9,5 +10,16 @@ const instance = axios.create({
   baseURL,
   withCredentials: true,
 });
+
+instance.interceptors.response.use(
+  (response) => {
+    return response;
+  },
+  (error) => {
+    const message = error.response?.data?.message || 'Щось пішло не так...';
+    toast.error(message);
+    return Promise.reject(error);
+  },
+);
 
 export default instance;


### PR DESCRIPTION
🚀 Що було зроблено:
Глобальні сповіщення:

Інтегровано бібліотеку react-hot-toast.

Створено ToasterProvider з кастомною стилізацією під бренд-бук проєкту (зелена палітра, закруглені кути).

Додано провайдер у кореневий layout.

Автоматизація помилок (Axios):

Налаштовано response interceptor в екземплярі Axios.

Тепер усі помилки від бекенду (400, 401, 404, 500) автоматично відображаються у вигляді тостів з текстом помилки від сервера.

SEO та Метадані (Task #29 update):

Повністю оновлено об'єкт metadata на сторінці мандрівників.

Додано розширений description та налаштовано OpenGraph (заголовки, описи та картинка прев'ю).

Перевірено відображення через SEO-інструменти (Title: 29 chars, Description: 145 chars).