### PR TITLE
Fix/forms and toasts

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -107,6 +107,22 @@ li {
   margin: 0 auto;
 }
 
+.custom-toast::after {
+  content: '✕';
+  position: absolute;
+  right: 15px;
+  top: 50%;
+  transform: translateY(-50%);
+  font-size: 14px;
+  opacity: 0.5;
+  font-weight: bold;
+}
+
+.custom-toast-error::after {
+  color: #cb2431;
+  opacity: 0.8;
+}
+
 @media only screen and (min-width: 768px) {
   .container {
     max-width: 768px;

--- a/components/providers/ToasterProvider.tsx
+++ b/components/providers/ToasterProvider.tsx
@@ -1,14 +1,12 @@
 'use client';
-
-import { Toaster } from 'react-hot-toast';
+import { Toaster, toast } from 'react-hot-toast';
 
 const ToasterProvider = () => {
   return (
     <Toaster
-      position="top-right"
-      reverseOrder={false}
-      gutter={12}
+      position="bottom-right"
       toastOptions={{
+        className: 'custom-toast',
         duration: 4000,
         style: {
           background: '#eef8ee',
@@ -16,33 +14,43 @@ const ToasterProvider = () => {
           borderRadius: '12px',
           fontSize: '18px',
           fontWeight: 500,
-          padding: '16px 20px',
+          padding: '16px 40px 16px 20px',
           border: '1px solid #1eb441',
           boxShadow: '0 4px 12px rgba(0, 0, 0, 0.08)',
           minWidth: '350px',
+          cursor: 'pointer',
         },
-        success: {
-          style: {
-            border: '1px solid #A3D9B1',
-          },
-          iconTheme: {
-            primary: '#2D9CDB',
-            secondary: '#F0F9F4',
-          },
-        },
+        success: { duration: 2500 },
         error: {
+          duration: 3000,
           style: {
             background: '#FFF5F5',
             border: '1px solid #FFCCCC',
             color: '#CB2431',
           },
-          iconTheme: {
-            primary: '#CB2431',
-            secondary: '#FFF5F5',
-          },
         },
       }}
-    />
+    >
+      {(t) => (
+        <div
+          onClick={() => toast.dismiss(t.id)}
+          className={t.className}
+          style={{
+            ...t.style,
+            display: 'flex',
+            alignItems: 'center',
+            opacity: t.visible ? 1 : 0,
+            transition: 'all 0.2s ease-in-out',
+          }}
+        >
+          <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
+            {t.icon}
+            {typeof t.message === 'function' ? t.message(t) : t.message}
+          </div>
+        </div>
+      )}
+    </Toaster>
   );
 };
+
 export default ToasterProvider;

--- a/components/ui/Select/Select.module.css
+++ b/components/ui/Select/Select.module.css
@@ -62,6 +62,23 @@
   z-index: 100;
   padding: 8px;
   list-style: none;
+  scrollbar-width: thin;
+  scrollbar-color: var(--opacity-neutral-darkest-15) transparent;
+}
+.dropdownList::-webkit-scrollbar {
+  width: 6px;
+}
+.dropdownList::-webkit-scrollbar-track {
+  background: transparent;
+}
+.dropdownList::-webkit-scrollbar-thumb {
+  background-color: var(--opacity-neutral-darkest-15);
+  border-radius: 10px;
+  transition: background-color var(--transition-default);
+}
+
+.dropdownList::-webkit-scrollbar-thumb:hover {
+  background-color: var(--color-neutral-dark);
 }
 
 .dropdownItem {

--- a/components/ui/TextArea/TextArea.module.css
+++ b/components/ui/TextArea/TextArea.module.css
@@ -22,14 +22,33 @@
   color: var(--color-scheme-2-text);
   font-family: inherit;
 
-  resize: vertical;
-  min-height: 80px;
+  resize: none;
+  min-height: 120px;
+  overflow-y: auto;
 
   transition:
     border-color var(--transition-default),
     box-shadow var(--transition-default);
+  scrollbar-width: thin;
+  scrollbar-color: var(--opacity-neutral-darkest-15) transparent;
 }
 
+.textarea::-webkit-scrollbar {
+  width: 6px;
+}
+
+.textarea::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.textarea::-webkit-scrollbar-thumb {
+  background-color: var(--opacity-neutral-darkest-15);
+  border-radius: 10px;
+}
+
+.textarea::-webkit-scrollbar-thumb:hover {
+  background-color: var(--color-neutral-dark);
+}
 .textarea:focus {
   border-color: var(--color-scheme-1-accent);
   box-shadow: 0 0 0 2px var(--color-mantis-lighter);

--- a/components/ui/TextArea/TextArea.tsx
+++ b/components/ui/TextArea/TextArea.tsx
@@ -1,4 +1,11 @@
-import { forwardRef, TextareaHTMLAttributes, useId } from 'react';
+'use client';
+import {
+  forwardRef,
+  TextareaHTMLAttributes,
+  useId,
+  useEffect,
+  useRef,
+} from 'react';
 import styles from './TextArea.module.css';
 
 interface TextAreaProps extends TextareaHTMLAttributes<HTMLTextAreaElement> {
@@ -7,10 +14,24 @@ interface TextAreaProps extends TextareaHTMLAttributes<HTMLTextAreaElement> {
 }
 
 export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
-  ({ label, error, className = '', id, ...props }, ref) => {
+  ({ label, error, className = '', id, value, ...props }, ref) => {
     const generatedId = useId();
     const textareaId = id || generatedId;
     const errorId = `${textareaId}-error`;
+
+    const internalRef = useRef<HTMLTextAreaElement | null>(null);
+
+    const updateHeight = () => {
+      const textarea = internalRef.current;
+      if (textarea) {
+        textarea.style.height = 'auto';
+        textarea.style.height = `${textarea.scrollHeight}px`;
+      }
+    };
+
+    useEffect(() => {
+      updateHeight();
+    }, [value]);
 
     return (
       <div className={`${styles.container} ${className}`}>
@@ -22,12 +43,20 @@ export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
 
         <div className={styles.textareaWrapper}>
           <textarea
-            ref={ref}
+            {...props}
+            value={value}
             id={textareaId}
             aria-invalid={!!error}
             aria-describedby={error ? errorId : undefined}
             className={`${styles.textarea} ${error ? styles.textareaError : ''}`}
-            {...props}
+            ref={(node) => {
+              internalRef.current = node;
+              if (typeof ref === 'function') {
+                ref(node);
+              } else if (ref) {
+                ref.current = node;
+              }
+            }}
           />
         </div>
         {error && (
@@ -39,5 +68,4 @@ export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
     );
   },
 );
-
 TextArea.displayName = 'TextArea';


### PR DESCRIPTION
Toaster: Повністю кастомізований, закривається по кліку на будь-яку частину повідомлення, має один охайний CSS-хрестик.

Select: Має тонкий, "адекватний" скролбалл, який не перекриває контент і з'являється лише тоді, коли елементів багато.

TextArea:

Заборонено ручне розтягування (resize: none).

Додано 'use client' для підтримки інтерактивності.

Реалізовано автовисоту: вона росте разом із текстом завдяки useEffect та scrollHeight.

Правильна робота з ref (через forwardRef), щоб зовнішні бібліотеки (як-от React Hook Form) не "відвалилися".

"Виправила тостери та селекти згідно з фідбеком. У текстерії реалізувала автовисоту через useEffect, щоб уникнути конфліктів з типами React. Через це додала 'use client' у компонент TextArea, оскільки він став інтерактивним. Перевірити локально не змогла через проблеми з авторизацією, глянь, будь ласка, чи все ок!"