### PR TITLE
fix: profile-edit-modal-routing

### DIFF
--- a/app/(private routes)/profile/@modal/(.)edit/page.tsx
+++ b/app/(private routes)/profile/@modal/(.)edit/page.tsx
@@ -1,14 +1,31 @@
 'use client';
+
+import { useEffect } from 'react';
 import { useRouter } from 'next/navigation';
+import { useModalStore } from '@/lib/store/useModalStore';
 import EditProfileContainer from '@/components/ProfilePage/EditProfileContainer/EditProfileContainer';
 import { Modal } from '@/components/ui/Modal/Modal';
 
 export default function EditProfileModal() {
   const router = useRouter();
+  const { isEditProfileOpen, closeEditProfile, openEditProfile } =
+    useModalStore();
+
+  useEffect(() => {
+    openEditProfile();
+  }, [openEditProfile]);
+
+  const handleClose = () => {
+    closeEditProfile();
+    router.push('/profile', { scroll: false });
+    router.refresh();
+  };
+
+  if (!isEditProfileOpen) return null;
 
   return (
-    <Modal onClose={() => router.back()}>
-      <EditProfileContainer onClose={() => router.back()} />
+    <Modal onClose={handleClose}>
+      <EditProfileContainer onClose={handleClose} />
     </Modal>
   );
 }

--- a/app/(private routes)/profile/layout.tsx
+++ b/app/(private routes)/profile/layout.tsx
@@ -6,6 +6,7 @@ import { useAuthStore } from '@/lib/store/useAuthStore';
 import TravellerInfo from '@/components/ui/TravellerInfo/TravellerInfo';
 import ProfileTabs from '@/components/ui/ProfileTabs/ProfileTabs';
 import { CustomLink } from '@/components/ui/Link/Link';
+import { useModalStore } from '@/lib/store/useModalStore';
 
 interface ProfileLayoutProps {
   saved: ReactNode;
@@ -23,6 +24,7 @@ export default function ProfileLayout({
   const pathname = usePathname();
   const user = useAuthStore((state) => state.user);
   const isMyStories = pathname === '/profile/my';
+  const openEditProfile = useModalStore((state) => state.openEditProfile);
 
   if (pathname.includes('confirm')) {
     return <>{children}</>;
@@ -39,7 +41,11 @@ export default function ProfileLayout({
                 avatar={user.avatarUrl}
                 storiesCount={user.articlesAmount || 0}
               >
-                <CustomLink variant="buttonProfile" href="/profile/edit">
+                <CustomLink
+                  variant="buttonProfile"
+                  href="/profile/edit"
+                  onClick={() => openEditProfile()}
+                >
                   Відредагувати профіль
                 </CustomLink>
               </TravellerInfo>

--- a/components/ProfilePage/EditProfileForm/EditProfileForm.tsx
+++ b/components/ProfilePage/EditProfileForm/EditProfileForm.tsx
@@ -248,7 +248,7 @@ export default function EditProfileForm({ onClose }: { onClose?: () => void }) {
                 type="button"
                 className={css.backBtn}
                 variant="secondary"
-                onClick={onClose || (() => window.history.back())}
+                onClick={onClose}
               >
                 Назад
               </Button>

--- a/lib/store/useModalStore.ts
+++ b/lib/store/useModalStore.ts
@@ -1,0 +1,13 @@
+import { create } from 'zustand';
+
+interface ModalState {
+  isEditProfileOpen: boolean;
+  openEditProfile: () => void;
+  closeEditProfile: () => void;
+}
+
+export const useModalStore = create<ModalState>((set) => ({
+  isEditProfileOpen: true,
+  openEditProfile: () => set({ isEditProfileOpen: true }),
+  closeEditProfile: () => set({ isEditProfileOpen: false }),
+}));


### PR DESCRIPTION
Цей PR реалізує повний функціонал редагування профілю користувача. Основна увага приділена стабільній роботі модального вікна через **Intercepting Routes** у Next.js, синхронізації стану за допомогою **Zustand** та забезпеченню безпеки приватних даних (SEO).

## 🚀 Що було зроблено:

### 🛠 Керування станом та Роутинг (Zustand + Next.js)
* **Global Modal State**: Впроваджено `useModalStore` (Zustand) для керування видимістю модалки. Це вирішило проблему "зависання" перехопленого маршруту при навігації.
* **Intercepting Routes**: Налаштовано слот `@modal` для безшовного відкриття форми редагування поверх сторінки профілю.
* **Надійна навігація**: 
    * Реалізовано логіку закриття, яка гарантовано перенаправляє користувача на `/profile`.
    * Використано `router.refresh()` для очищення серверного кешу слотів при закритті.
    * Додано `default.tsx` для коректного рендеру паралельних маршрутів.


## 🔍 Як протестувати:
1. Авторизуватися та перейти в **Профіль**.
2. Натиснути **"Відредагувати профіль"**: має відкритися модалка без перезавантаження сторінки (URL зміниться на `/profile/edit`).
4. **Закриття**: 
    * Перевірити закриття через кнопку "Назад", хрестик, клік по фону або клавішу `Esc`.
    * URL має завжди повертатися на `/profile`, а модалка — повністю зникати.
5. **Прямий лінк**: Скопіювати посилання `/profile/edit`, відкрити в новій вкладці — сторінка має відкритися як повноцінна сторінка (fallback), а не модалка.

